### PR TITLE
Fix line endings and encoding for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Ensure correct line endings and encoding for VBA files
+*.bas eol=crlf working-tree-encoding=Shift_JIS
+*.cls eol=crlf working-tree-encoding=Shift_JIS
+*.frm eol=crlf working-tree-encoding=Shift_JIS

--- a/VBA package/class module/Dxfclass.cls
+++ b/VBA package/class module/Dxfclass.cls
@@ -29,7 +29,7 @@ Function getSaveAspath_2()
         getSaveAspath_2 "a"
     End If
 End Function
-Function Init_dxfclass() '‰Šú‘ã“üŠÖ”
+Function Init_dxfclass() 'åˆæœŸä»£å…¥é–¢æ•°
     path = DesktopFilepath
     ChDir path
     save_path = Application.GetSaveAsFilename("output", filefilter:="DXFdata(*.dxf;),", Title:="submit generate dxf file")
@@ -3207,7 +3207,7 @@ Sub header()
         Print #1, "70"
         Print #1, "64"
         Print #1, "3"
-        Print #1, "?_?~?["
+        Print #1, "?_?â€¾?["
         Print #1, "72"
         Print #1, "65"
         Print #1, "73"
@@ -4125,5 +4125,5 @@ Sub header()
     Close #1
 End Sub
 Function DesktopFilepath() As String
-    DesktopFilepath = "C:\Users\" & Environ("Username") & "\Desktop\"
+    DesktopFilepath = "C:Â¥UsersÂ¥" & Environ("Username") & "Â¥DesktopÂ¥"
 End Function

--- a/VBA package/code_example/DXFnamer.bas
+++ b/VBA package/code_example/DXFnamer.bas
@@ -9,11 +9,11 @@ Sub main()
     Dim getline As String
     Dim txtline() As String
     Dim dxf As New Dxfclass
-    originpath = dxf.getOriginpath() 'レイヤ名の無いファイルを選択する�
+    originpath = dxf.getOriginpath() 'レイヤ名の無いファイルを選択する?
     
     If (originpath = "") Then Exit Sub
     
-    generatepath = dxf.getSaveAspath() 'ファイルの保存先を指定する�
+    generatepath = dxf.getSaveAspath() 'ファイルの保存先を指定する?
     
     If (generatepath = originpath) Then Exit Sub
     

--- a/VBA package/code_example/generate_diiagram_dxf.bas
+++ b/VBA package/code_example/generate_diiagram_dxf.bas
@@ -12,7 +12,7 @@ Sub main()
     For j = 1 To 10
         n = j
         deg = 360 / n
-        fpath = dxf.DesktopFilepath & "take1\" & j & ".dxf"
+        fpath = dxf.DesktopFilepath & "take1¥" & j & ".dxf"
         
         dxf.header (fpath)
         


### PR DESCRIPTION
In this PR, I used `eol=crlf` to avoid issues people could face with importing your code files with the VBE after downloading or cloning from GitHub ([more info](https://github.com/DecimalTurn/VBA-on-GitHub/blob/main/README.md#should-you-include--textauto-in-your-gitattributes)). 

I also used `working-tree-encoding=Shift_JIS` ~~because [Shift_JIS](https://en.wikipedia.org/wiki/Shift_JIS) is the encoding used by the VBE for Japanese. This should fix issues with displaying Japanese characters on GitHub.~~

Fixes https://github.com/DecimalTurn/VBA-GitHub-Checks/issues/859